### PR TITLE
Add CODEOWNERS assigning @dreamdata-io/data-sources-destinations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# These owners will be the default owners for everything
-
-* gugabfigueiredo@gmail.com jinglin.daisy@gmail.com mageirasjohn@gmail.com
+* @dreamdata-io/data-sources-destinations


### PR DESCRIPTION
Assigns repository ownership to `@dreamdata-io/data-sources-destinations`, per the repo inventory review (dreamdata-io/inventory#3).

Single-line CODEOWNERS, no empty lines.